### PR TITLE
Add colon to allowed characters

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@ variable "interface_profile" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.interface_profile))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.interface_profile))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
 
@@ -13,8 +13,8 @@ variable "name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.name))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
 
@@ -35,8 +35,8 @@ variable "fex_interface_profile" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.fex_interface_profile))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.fex_interface_profile))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
 
@@ -57,8 +57,8 @@ variable "policy_group" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.policy_group))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.policy_group))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
 
@@ -76,9 +76,9 @@ variable "port_blocks" {
 
   validation {
     condition = alltrue([
-      for pb in var.port_blocks : can(regex("^[a-zA-Z0-9_.-]{0,64}$", pb.name))
+      for pb in var.port_blocks : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", pb.name))
     ])
-    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 
   validation {
@@ -133,9 +133,9 @@ variable "sub_port_blocks" {
 
   validation {
     condition = alltrue([
-      for pb in var.sub_port_blocks : can(regex("^[a-zA-Z0-9_.-]{0,64}$", pb.name))
+      for pb in var.sub_port_blocks : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", pb.name))
     ])
-    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 
   validation {


### PR DESCRIPTION
Existing Cisco ACI customers use colons in leaf interface profile selector names and port block names. Example:

````
    leaf_interface_profiles:
      - name: LIP1
        selectors:
          - name: '1:50'
            policy_group: PG1
            port_blocks:
              - name: '1:50'
                from_port: 50
````

Colons are allowed in the data model for this module defined in:

https://developer.cisco.com/docs/nexus-as-code/#!access-leaf-interface-profile

However colons are actually not allowed in this module. As customers do not want to change their existing ACI naming conventions, we request to allow colons in the selector names and port block names. For consistency, I suggest to allow it for all name variables defined in this module. 